### PR TITLE
Add AG2

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Private AI enables you to keep your data, models, and infrastructure **under you
 ## Agents & Orchestration
 > Frameworks for chaining private AI tools & agents.
 
+- [AG2](https://github.com/ag2ai/ag2) - Open-source operating system for agentic AI with native Ollama support for local model deployment and multi-agent collaboration.
 - [LangChain](https://www.langchain.com/) - Agent and LLM orchestration framework.
 - [Langflow](https://github.com/langflow-ai/langflow) - Visual workflow builder for creating and deploying AI-powered agents and workflows with built-in API servers.
 - [Haystack](https://haystack.deepset.ai) - End-to-end RAG pipelines.


### PR DESCRIPTION
## Summary
- Add AG2 (formerly AutoGen) to the Agents & Orchestration section
- AG2 is an open-source operating system for agentic AI with native Ollama support for local model deployment

## Details
AG2 provides:
- Native Ollama integration for local model deployment
- Multi-agent collaboration capabilities  
- Tool calling support
- 3.4k GitHub stars

Closes #12

🤖 Generated with [Claude Code](https://claude.ai/code)