### PR TITLE
Add dakera-mcp to Agents & Orchestration — private self-hosted agent memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Private AI enables you to keep your data, models, and infrastructure **under you
  - [dspy](https://github.com/stanfordnlp/dspy) - Modular, open-source agent framework for building composable, private LLM applications and workflows.
 - [CUA](https://github.com/trycua/cua) -  enables AI agents to control full operating systems in virtual containers and deploy them locally or to the cloud.
 - [Bytebot](https://github.com/bytebot-ai/bytebot) - A desktop agent is an AI that has its own computer. Unlike browser-only agents or traditional RPA tools, Bytebot comes with a full virtual desktop.
+- [dakera-mcp](https://github.com/dakera-ai/dakera-mcp) - Self-hosted, MCP-native agent memory server. Agents store and retrieve memories privately via 83 MCP tools — no cloud, full data sovereignty. RocksDB+HNSW backend, 87.8% LoCoMo benchmark.
 
 
 ## VS Code Plugins & Extensions


### PR DESCRIPTION
## dakera-mcp

[dakera-mcp](https://github.com/dakera-ai/dakera-mcp) is a self-hosted, MCP-native agent memory server purpose-built for privacy-first deployments.

**Why it belongs in Agents & Orchestration:**
- Runs entirely on your own infrastructure — zero external API calls, full data sovereignty
- Agents store and retrieve memories via 83 native MCP tools with no cloud dependency
- RocksDB persistence + HNSW vector search, deployed via Docker Compose
- Decay-weighted recall prevents memory bloat while keeping relevant context accessible
- 87.8% LoCoMo benchmark score for long-term conversational memory

**Privacy angle:**
Every memory stays on your server. No telemetry, no third-party services. Ideal for enterprise, healthcare, legal, and any deployment where agent conversation history cannot leave your infrastructure.