### PR TITLE
Add WhisperSubTranslate

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Private AI enables you to keep your data, models, and infrastructure **under you
 - [LibreChat](https://github.com/danny-avila/LibreChat) - Enhanced web UI for LLMs.
 - [AnythingLLM](https://anythingllm.com/) - Full-stack private LLM workspace.
 - [Open WebUI](https://github.com/open-webui/open-webui) - Commonly recommended Web UI frontend which features built in search, web scrape, RAG, and optional user authentication.
+- [WhisperSubTranslate](https://github.com/Blue-B/WhisperSubTranslate) - Privacy-first desktop app that generates translated subtitles from any video locally. Uses whisper.cpp for speech and a local LLM (HY-MT GGUF via node-llama-cpp) for translation; no audio or text leaves the machine.
 
 
 


### PR DESCRIPTION
Adds [WhisperSubTranslate](https://github.com/Blue-B/WhisperSubTranslate) to UI & Interaction Layers.

Electron desktop app (GPL-3.0) that turns any video into translated subtitles with everything running locally. Speech-to-text via whisper.cpp (already in the list under Inference Runtimes), translation via a local LLM (HY-MT 1.8B/7B GGUF through node-llama-cpp) — no audio or transcript leaves the user's machine. Falls back to DeepL/OpenAI/Gemini/MyMemory only if the user explicitly provides their own keys. 14 target languages, batch queue. Latest release v2.0.0.