### PR TITLE
Add Future AGI to Privacy Security and Governance

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Private AI enables you to keep your data, models, and infrastructure **under you
 - [OpenFL](https://github.com/IntelLabs/openfl) - Federated learning framework.
 - [Flower](https://flower.dev) - Federated learning at scale.
 - [Concrete](https://github.com/zama-ai/concrete) - Fully homomorphic encryption for AI.
+- [Future AGI](https://github.com/future-agi/future-agi) - Open-source self-hostable end-to-end agent engineering and optimization platform unifying tracing, evaluation, simulation, datasets, gateway, and guardrails in one feedback loop.
 
 
 


### PR DESCRIPTION
This PR adds open-source Future AGI projects to the most relevant section(s) of the list.

All entries are Apache 2.0 licensed.

- traceAI: https://github.com/future-agi/traceAI
- ai-evaluation: https://github.com/future-agi/ai-evaluation
- agent-opt: https://github.com/future-agi/agent-opt
- simulate-sdk: https://github.com/future-agi/simulate-sdk
- agent-command-center-sdk: https://github.com/future-agi/agent-command-center-sdk
- future-agi (umbrella): https://github.com/future-agi/future-agi
- futureagi-mcp-server: https://github.com/future-agi/futureagi-mcp-server

Description style and placement match the existing entries in the chosen section. Single-purpose diff: only README updates.