### PR TITLE
Add 5dive to Agents & Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Private AI enables you to keep your data, models, and infrastructure **under you
  - [dspy](https://github.com/stanfordnlp/dspy) - Modular, open-source agent framework for building composable, private LLM applications and workflows.
 - [CUA](https://github.com/trycua/cua) -  enables AI agents to control full operating systems in virtual containers and deploy them locally or to the cloud.
 - [Bytebot](https://github.com/bytebot-ai/bytebot) - A desktop agent is an AI that has its own computer. Unlike browser-only agents or traditional RPA tools, Bytebot comes with a full virtual desktop.
+- [5dive](https://github.com/5dive-ai/5dive) - Open-source self-hosted multi-agent runtime. Spawn a persistent team of autonomous AI agents on your own Linux box, each with its own Claude Code session, driven from Telegram, off your existing Claude subscription — no metered API.
 
 
 ## VS Code Plugins & Extensions


### PR DESCRIPTION
Adds **5dive** to *Agents & Orchestration* (appended at the bottom of the section).

5dive is an open-source, self-hosted multi-agent runtime: spawn a persistent team of autonomous agents on your own Linux box, each running its own Claude Code session, driven from Telegram and running off your existing Claude subscription (no metered API). It fits the private/self-hosted-AI focus of this list — everything runs on hardware you control with your own keys and bot.

- Open source, MIT licensed: https://github.com/5dive-ai/5dive
- Actively maintained (commits this week)
- Launched on Product Hunt: https://www.producthunt.com/posts/5dive

Thanks for maintaining the list!