### PR TITLE
Add CorvinOS — agentic OS with structural EU AI Act & GDPR compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Private AI enables you to keep your data, models, and infrastructure **under you
  - [dspy](https://github.com/stanfordnlp/dspy) - Modular, open-source agent framework for building composable, private LLM applications and workflows.
 - [CUA](https://github.com/trycua/cua) -  enables AI agents to control full operating systems in virtual containers and deploy them locally or to the cloud.
 - [Bytebot](https://github.com/bytebot-ai/bytebot) - A desktop agent is an AI that has its own computer. Unlike browser-only agents or traditional RPA tools, Bytebot comes with a full virtual desktop.
+- [CorvinOS](https://github.com/CorvinLabs/CorvinOS) - Self-hosted agentic OS that connects local Ollama models and cloud providers to Discord, Telegram, WhatsApp, Slack, and Email. EU AI Act 2026 and GDPR compliance are structural constraints built into the architecture — bot-disclosure, consent gate, hash-chained audit log, and right-to-erasure orchestrator cannot be disabled by configuration.
 
 
 ## VS Code Plugins & Extensions
@@ -114,6 +115,7 @@ Private AI enables you to keep your data, models, and infrastructure **under you
 - [OpenFL](https://github.com/IntelLabs/openfl) - Federated learning framework.
 - [Flower](https://flower.dev) - Federated learning at scale.
 - [Concrete](https://github.com/zama-ai/concrete) - Fully homomorphic encryption for AI.
+- [CorvinOS](https://github.com/CorvinLabs/CorvinOS) - Self-hosted agentic OS with EU AI Act 2026 and GDPR compliance built into the architecture. Bot-disclosure (Art. 50), consent gate (Art. 6/7), hash-chained audit log (Art. 30/32), and GDPR erasure orchestrator (Art. 17) are structural constraints — none can be disabled by configuration or environment variable.
 
 
 


### PR DESCRIPTION
## What

Adds [CorvinOS](https://github.com/CorvinLabs/CorvinOS) to two sections:

1. **Agents & Orchestration** — self-hosted agentic OS that connects local Ollama models and cloud providers to Discord, Telegram, WhatsApp, Slack, and Email
2. **Privacy, Security & Governance** — EU AI Act 2026 and GDPR compliance are structural constraints, not configuration options

## Why it fits

CorvinOS explicitly requires local model deployment (via Ollama / `--engine hermes`) and is designed for zero-egress private deployments. The compliance mechanisms are load-bearing Python code:

- Bot-disclosure (EU AI Act Art. 50) — structurally fail-closed, no bypass path
- Per-user consent gate (GDPR Art. 6/7) — deny-by-default
- Hash-chained audit log (GDPR Art. 30/32) — chain write failure blocks request
- GDPR Art. 17 erasure orchestrator — cross-layer, runs on demand

None of these can be disabled by environment variable or config flag.

## Links

- GitHub: https://github.com/CorvinLabs/CorvinOS (Apache-2.0, public since 2026-06-28)
- PyPI: https://pypi.org/project/corvinos/ (`pip install corvinos`)