### PR TITLE
Add lilbee to Model Management & Serving

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Private AI enables you to keep your data, models, and infrastructure **under you
 - [BentoML](https://www.bentoml.com/) - Model packaging & serving framework.
 - [vLLM Production Stack](https://github.com/vllm-project/production-stack) - End-to-end stack for deploying vLLM in production, including orchestration, monitoring, autoscaling, and best practices for private LLM serving.
 - [OME (Open Model Engine)](https://docs.sglang.ai/ome/) - Unified, open-source engine for serving, managing, and scaling LLMs and multimodal models privately. Supports sglang, vLLM, and more.
+- [lilbee](https://github.com/tobocop2/lilbee) - Local-first, single-binary model manager and search engine: runs a llama-server fleet sized by gguf-parser (or uses your Ollama/LM Studio) and answers over your files and code with citations.
 
 ## Fine-Tuning & Adapters
 > Private workflows for adapting models to your needs.


### PR DESCRIPTION
lilbee is the whole local-AI stack in a single executable, and it fits a private-AI list because it runs entirely on your own hardware and only touches the cloud if you point it at a cloud model. It runs the models itself, indexes everything you own (90+ file formats and 150+ programming languages, thanks to xberg), crawls and saves web pages, and answers questions about all of it with file-and-line citations. No separate model server, no vector database, no containers to configure. It has its own model manager built on llama.cpp, or you point it at your existing Ollama or LM Studio.

The single executable's terminal UI adds a document, then answers with a file-and-line citation, fully offline:

![lilbee's terminal UI adding a document, then answering with a file-and-line citation](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-add.gif)

The private, offline part is the whole point for the people I built it with. A PhD-chemist friend indexed her microscope's Python SDK manual and, completely offline from a PDF, produced a fully working control script she could never have written on her own. A non-technical friend from the Obsidian forum who had never opened a terminal in his life was talking to his solar-panel documents within minutes, his first successful experience with local AI. That's the mission: talk to your own websites and documents privately, an Encarta made out of your own stuff.

That non-technical friend never touched the terminal, because lilbee is also an [Obsidian community plugin](https://community.obsidian.md/plugins/lilbee):

![the lilbee Obsidian community plugin](https://raw.githubusercontent.com/tobocop2/obsidian-lilbee/gh-pages/demos/what_is_lilbee.gif)

[xberg](https://github.com/xberg-io/xberg) powers all of lilbee's document intelligence; I'm on its open-source team, where I've contributed a good deal, including chunking for CSV, XML, Markdown, and YAML, JSONL support, and semantic chunking. A multi-GPU fleet manager (llama-server + llama-swap) scales the whole stack (chat, embedding, vision, reranking) across every GPU in the machine, still one executable.

I placed it under Model Management & Serving as the local-first, single-machine counterpart to the production serving stacks already there. Site: https://lilbee.sh . Obsidian community plugin: https://community.obsidian.md/plugins/lilbee (site: https://obsidian.lilbee.sh ). Code: https://github.com/tobocop2/lilbee . Tutorial reels: https://lilbee.sh/tutorial/ and https://obsidian.lilbee.sh/tutorial/ . MIT, Python, actively maintained. Thanks for keeping this list curated.
