### PR TITLE
Add Off Grid AI Desktop to UI & Interaction Layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Private AI enables you to keep your data, models, and infrastructure **under you
 - [LibreChat](https://github.com/danny-avila/LibreChat) - Enhanced web UI for LLMs.
 - [AnythingLLM](https://anythingllm.com/) - Full-stack private LLM workspace.
 - [Open WebUI](https://github.com/open-webui/open-webui) - Commonly recommended Web UI frontend which features built in search, web scrape, RAG, and optional user authentication.
-- [Off Grid AI Desktop](https://getoffgridai.co/desktop) - Private, local-first macOS desktop app running local LLM chat, image generation, whisper dictation, and RAG entirely on-device via llama.cpp; nothing leaves the machine. AGPL-3.0.
+- [Off Grid AI Desktop](https://github.com/off-grid-ai/OGAD) - Private, local-first macOS desktop app running local LLM chat, image generation, whisper dictation, and RAG entirely on-device via llama.cpp; nothing leaves the machine. AGPL-3.0.
 
 
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Private AI enables you to keep your data, models, and infrastructure **under you
 - [LibreChat](https://github.com/danny-avila/LibreChat) - Enhanced web UI for LLMs.
 - [AnythingLLM](https://anythingllm.com/) - Full-stack private LLM workspace.
 - [Open WebUI](https://github.com/open-webui/open-webui) - Commonly recommended Web UI frontend which features built in search, web scrape, RAG, and optional user authentication.
+- [Off Grid AI Desktop](https://getoffgridai.co/desktop) - Private, local-first macOS desktop app running local LLM chat, image generation, whisper dictation, and RAG entirely on-device via llama.cpp; nothing leaves the machine. AGPL-3.0.
 
 
 


### PR DESCRIPTION
## What
Adds [Off Grid AI Desktop](https://github.com/off-grid-ai/OGAD) to **UI & Interaction Layers**, alongside AnythingLLM, LibreChat, and Open WebUI.

## About
Open-source (AGPL-3.0) macOS app - a private local-first AI frontend that runs LLM chat, image generation, whisper dictation, and RAG entirely on-device via llama.cpp. Encrypted vault, MCP connectors. Nothing leaves the machine.

Disclosure: I'm involved with the project.
