### PR TITLE
docs: add NULLA to Agents & Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Private AI enables you to keep your data, models, and infrastructure **under you
  - [dspy](https://github.com/stanfordnlp/dspy) - Modular, open-source agent framework for building composable, private LLM applications and workflows.
 - [CUA](https://github.com/trycua/cua) -  enables AI agents to control full operating systems in virtual containers and deploy them locally or to the cloud.
 - [Bytebot](https://github.com/bytebot-ai/bytebot) - A desktop agent is an AI that has its own computer. Unlike browser-only agents or traditional RPA tools, Bytebot comes with a full virtual desktop.
+- [NULLA](https://github.com/Parad0x-Labs/nulla-local) - Local-first, private AI agent that runs on your machine and signs offline-verifiable receipts of its actions.
 
 
 ## VS Code Plugins & Extensions


### PR DESCRIPTION
Adds NULLA, a local-first AI agent (Ollama-based, MIT, Alpha) that runs fully on the user's machine and signs an offline-verifiable receipt of each action (what it claimed vs. what actually ran).

Repo: https://github.com/Parad0x-Labs/nulla-local
