### PR TITLE
Add DeepCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Private AI enables you to keep your data, models, and infrastructure **under you
 - [CUA](https://github.com/trycua/cua) -  enables AI agents to control full operating systems in virtual containers and deploy them locally or to the cloud.
 - [Bytebot](https://github.com/bytebot-ai/bytebot) - A desktop agent is an AI that has its own computer. Unlike browser-only agents or traditional RPA tools, Bytebot comes with a full virtual desktop.
 - [MFS](https://github.com/zilliztech/mfs) - Exposes your code, docs, chat (Slack/Gmail/Jira), databases and object stores as one file-like, searchable namespace for agents (`ls`/`cat`/`grep` + semantic search); runs fully local with on-device ONNX embeddings on Milvus, no API key.
+- [DeepCode](https://github.com/HKUDS/DeepCode) - Open agentic coding framework that turns papers and specs into working code (Paper2Code, Text2Web, Text2Backend), running against local Ollama or vLLM backends.
 
 
 ## VS Code Plugins & Extensions


### PR DESCRIPTION
Adds [DeepCode](https://github.com/HKUDS/DeepCode) to **Agents & Orchestration**.

Closes #18.

Meets the submission criteria:

- **Local deployment** — the README documents Ollama and vLLM as supported backends alongside hosted providers, so it runs entirely against private models.
- **Open source** — MIT licensed.
- **Actively maintained** — last push 2026-08-09.
- **Stars** — 16.3k, well above the 100+ bar.
- **Documentation** — full install and configuration instructions in the repo README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)