### PR TITLE
Add oMLX

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Private AI enables you to keep your data, models, and infrastructure **under you
 - [tabbyAPI](https://github.com/theroyallab/tabbyAPI) - Official API server for running exllamav2 and exllamav3 models. Aims to be a friendly backend with high customizablity and an idiotmatic OAI compatible API for users.
 - [YALS (Yet another llamacpp server)](https://gtihub.com/theroyallab/YALS) - TabbyAPI's sister project, adapted for llama.cpp and GGUF models. Built from the ground up using libllama instead of wrapping llama-server.
 - [llama-swap](https://github.com/mostlygeek/llama-swap) - Model swapping for llama.cpp (or any local OpenAPI compatible server).
+- [oMLX](https://github.com/jundot/omlx) - macOS-native MLX inference server with paged SSD KV caching and continuous batching. Serves LLM, VLM, embedding, and reranker models over OpenAI- and Anthropic-compatible endpoints for local coding agents on Apple Silicon.
 
 
 ## Model Management & Serving


### PR DESCRIPTION
Adds [oMLX](https://github.com/jundot/omlx) to **Inference Runtimes & Backends**.

A macOS-native MLX server: paged SSD KV caching (hot blocks in RAM, cold on disk, restored across server restarts), continuous batching via `mlx-lm`'s BatchGenerator, and simultaneous LLM/VLM/embedding/reranker serving. Exposes both OpenAI- and Anthropic-compatible endpoints, so local coding agents point at it directly.

Meets the submission criteria:

- **Local deployment** — runs entirely on-device on Apple Silicon; that is the whole product.
- **Open source** — Apache-2.0.
- **Actively maintained** — last push 2026-08-10.
- **Stars** — 18.6k, well above the 100+ bar.
- **Documentation** — install, benchmarks, and per-tool config at https://omlx.ai/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)