### PR TITLE
Add Atomic Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Private AI enables you to keep your data, models, and infrastructure **under you
 - [MFS](https://github.com/zilliztech/mfs) - Exposes your code, docs, chat (Slack/Gmail/Jira), databases and object stores as one file-like, searchable namespace for agents (`ls`/`cat`/`grep` + semantic search); runs fully local with on-device ONNX embeddings on Milvus, no API key.
 - [DeepCode](https://github.com/HKUDS/DeepCode) - Open agentic coding framework that turns papers and specs into working code (Paper2Code, Text2Web, Text2Backend), running against local Ollama or vLLM backends.
 - [Skales](https://github.com/skalesapp/skales) - Source-available (BSL 1.1) local-first desktop AI agent that runs fully on-device, offline via Ollama or with 15+ providers; your files never leave your machine, no cloud required.
+- [Atomic Agent](https://github.com/AtomicBot-ai/atomic-agent) - Local-first CLI and TUI coding agent that runs open-weight models entirely on your machine through a llama.cpp fork, with no account or API key required. Ships 56 built-in tools (browser, filesystem, git, memory, vision), MCP support and a five-layer local memory system on macOS, Linux and Windows.
 
 
 ## VS Code Plugins & Extensions


### PR DESCRIPTION
Adds [Atomic Agent](https://github.com/AtomicBot-ai/atomic-agent) to **Agents & Orchestration**.

Hi! I'm the CPO of Atomic Agent. Thanks for this great list, our team would be thrilled if you added us. It sits naturally next to Aider, Goose and Crush: a local-first CLI and TUI coding agent that runs open-weight models entirely on your machine through a llama.cpp fork, with no account or API key required to install or run it.

Meets the submission criteria:

- **Local model deployment** - runs open-weight models entirely on your machine via a bundled llama.cpp fork. No account or API key required.
- **Open source** - MIT licensed.
- **Actively maintained** - commits within the last few days.
- **Stars** - ~2k, above the 100+ bar.
- **Documentation** - install and configuration docs at https://atomicagent.io/docs, one-line install: `curl -fsSL https://atomicagent.io/install | sh`

A bit more on what it does: 56 built-in tools (browser, filesystem, git, memory, vision), MCP support, a five-layer local memory system, and a TUI built on React and ink. Cross-platform on macOS, Linux and Windows.

One note in the interest of full transparency: the project itself is about 4 months old. It is actively maintained and already at ~2k stars, and it comes from the AtomicBot-ai organization, which ships several established projects.

Links: [site](https://atomicagent.io) | [docs](https://atomicagent.io/docs) | [X](https://x.com/atomicagent_io) | [Discord](https://discord.gg/Us7qXtDGw)

Happy to adjust the wording or move the entry if you'd prefer it phrased differently.
