### PR TITLE
Add Orkas

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Private AI enables you to keep your data, models, and infrastructure **under you
 - [Herdr](https://herdr.dev/) - Self-hosted runtime and terminal multiplexer for coding agents. Runs the agent CLIs on your own machine or a box you control, grouping them into workspaces you can detach from and reattach to over SSH.
 - [Crush](https://github.com/charmbracelet/crush) - Privacy-first, open-source agentic coding and automation platform for local AI workflows.
 - [OpenCode AI](https://opencode.ai/) - Open-source agentic coding platform for private, local, and secure AI-powered development workflows.
+- [Orkas](https://github.com/Orkas-AI/Orkas) - Open-source, local-first desktop AI workforce whose Commander coordinates specialist agents through one chat; model calls can use a compatible local endpoint.
 - [Goose](https://github.com/block/goose) - Local, extensible agent that runs on your machine and works against any LLM backend, including Ollama and other self-hosted endpoints.
 - [Aider](https://github.com/Aider-AI/aider) - Terminal-based pair programming agent that edits code in your local git repo, with support for local models via Ollama and OpenAI-compatible servers.
 - [PydanticAI](https://github.com/pydantic/pydantic-ai) - Python agent framework by the Pydantic team, model-agnostic with Ollama support for local deployment.


### PR DESCRIPTION
Adds Orkas to Agents & Orchestration as an open-source, local-first desktop AI workforce. It supports compatible local model endpoints, is actively maintained, and links to the canonical repository only.

Validation: duplicate search, canonical link check, and `git diff --check` passed. This is a project-affiliated submission.