### PR TITLE
Add Local Waifu

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Private AI enables you to keep your data, models, and infrastructure **under you
 - [text-generation-webui](https://github.com/oobabooga/text-generation-webui) - Long-standing Gradio web UI for local text generation, supporting llama.cpp, ExLlama, and transformers backends.
 - [SillyTavern](https://github.com/SillyTavern/SillyTavern) - Self-hosted, highly customizable frontend for local models, with extensive character, prompt, and context management.
 - [Screenpipe](https://github.com/screenpipe/screenpipe) - 24/7 local screen + microphone recording with OCR, audio transcription, and semantic search. Fully offline with Ollama or any local LLM. MCP server for Claude.
+- [Local Waifu](https://localwaifu.com) - Desktop AI companion for macOS and Windows that bundles its own local model runtime, image generation and speech; runs fully offline with no account or telemetry.
 
 
 ## Image & Video Generation


### PR DESCRIPTION
Adds [Local Waifu](https://localwaifu.com) to **UI & Interaction Layers**.

### Why it fits

A desktop app for macOS and Windows that ships its own local model runtime in the installer, alongside on-device image generation and local speech-to-text. First launch sizes a model to the machine's RAM and pulls it; after that the whole thing runs offline. There is no account, no telemetry, and no server component — block every outbound connection and it keeps working, which is the air-gapped case rather than an approximation of it.

Users who prefer a remote model can point it at any OpenAI-compatible endpoint with their own key, so local is the default rather than the only option.

Closest neighbour already in the section is Screenpipe: a local-first desktop app rather than a self-hosted web frontend.

### Against the submission requirements

- **Local model deployment** — yes, and it is the default path, not an optional backend.
- **Actively maintained** — v1.6.3 released 14 Aug 2026; releases have run continuously since June 2026.
- **Documentation and install instructions** — README and signed installers at https://github.com/lumizone/local-waifu/releases/latest, full docs at https://localwaifu.com
- **100+ GitHub stars** — this one it does not meet, and I would rather say so than let you find it. The linked repo is a distribution repo (README, releases, installers), not a source repo, so its star count reflects nothing about the project's maturity. The app itself is a shipping paid product, not a weekend prototype. Entirely your call whether that exception is worth making on an opinionated list.
- **Open source** — no. Proprietary, one-time licence, no source published. Per your rules that is "preferred but not limited to", and the "no self-hosting" exclusion does not apply since it runs entirely on the user's own hardware.

Note on placement: the section is not currently in alphabetical order, so I appended rather than guessing at an intended position. Happy to move it.

Disclosure: I'm the author.