### PR TITLE
Add Persona to UI & Interaction Layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Private AI enables you to keep your data, models, and infrastructure **under you
 - [text-generation-webui](https://github.com/oobabooga/text-generation-webui) - Long-standing Gradio web UI for local text generation, supporting llama.cpp, ExLlama, and transformers backends.
 - [SillyTavern](https://github.com/SillyTavern/SillyTavern) - Self-hosted, highly customizable frontend for local models, with extensive character, prompt, and context management.
 - [Screenpipe](https://github.com/screenpipe/screenpipe) - 24/7 local screen + microphone recording with OCR, audio transcription, and semantic search. Fully offline with Ollama or any local LLM. MCP server for Claude.
+- [Persona](https://github.com/jayamitkatariya/personacli) - Local-first personal workspace: notes and tasks as plain Markdown on your machine, with an AI chat grounded in your own files. Runs fully local with Ollama.
 
 
 ## Image & Video Generation


### PR DESCRIPTION
Adds [Persona](https://github.com/jayamitkatariya/personacli) to **UI & Interaction Layers**.

Persona is a local-first personal workspace: Markdown notes and tasks stored entirely on the user's machine, with an AI chat grounded in those files. Runs fully locally via Ollama or any OpenAI-compatible endpoint — data never leaves the machine. MIT.